### PR TITLE
Improve loot tables

### DIFF
--- a/run.py
+++ b/run.py
@@ -163,7 +163,7 @@ if 'bosses' in categories:
         print_progress("Parsing boss loot", index, len(files))
 
         parsed = parser.parse(dbr)
-        if not parsed:
+        if not parsed or 'tag' not in parsed:
             continue
 
         bossTag, boss = pluck(parsed, 'tag', 'result')

--- a/tqdb/constants/resources.py
+++ b/tqdb/constants/resources.py
@@ -99,6 +99,10 @@ CHESTS = {
         'bosschest09_pharaohshonorguard_epic.dbr',
         'records\\item\\containers\\boss\\'
         'bosschest09_pharaohshonorguard_legendary.dbr'],
+    'tagMonsterName1129': [
+        'records\\item\\containers\\boss\\bosschest08x_masika_normal.dbr',
+        'records\\item\\containers\\boss\\bosschest08x_masika_epic.dbr',
+        'records\\item\\containers\\boss\\bosschest08x_masika_legendary.dbr'],
     'tagMonsterName060': [
         'records\\item\\containers\\boss\\'
         'bosschest12_sandwraithlord_normal.dbr',
@@ -300,8 +304,8 @@ CHESTS = {
     }
 
 CREATURES = [
-    'records\\creature\\monster\\questbosses\\*.dbr',
-    'records\\xpack*\\creatures\\monster\\bosses\\**\\*.dbr']
+    'records\\creature\\monster\\**\\*.dbr',
+    'records\\xpack*\\creatures\\monster\\**\\*.dbr']
 
 EQUIPMENT_BASE = [
     'records\\xpack*\\item\\equipment*\\**\\*.dbr',

--- a/tqdb/parsers/boss.py
+++ b/tqdb/parsers/boss.py
@@ -49,6 +49,7 @@ class BossLootParser():
 
         # Skip tagless, existing, classless or Common bosses:
         if (not boss_tag or (
+                boss_class != 'Hero' and
                 boss_class != 'Boss' and
                 boss_class != 'Quest')):
             return boss

--- a/tqdb/parsers/boss.py
+++ b/tqdb/parsers/boss.py
@@ -101,9 +101,9 @@ class BossLootParser():
                     # Parse the table and multiply the values by the chance:
                     loot_ref = loot.get(f'loot{equipment}Item{i}')
 
-                    # There are some hero/boss files that have a '#' as
-                    # placeholder for a difficulty without loot, skip those:
-                    if not loot_ref or loot_ref == '#':
+                    # There are some hero/boss files that have an invalid
+                    # path as the property for the loot reference:
+                    if not loot_ref or not util.get_reference_dbr(loot_ref):
                         logging.warning(
                             f'Empty loot{equipment}Item{i} in {self.dbr}')
                         continue

--- a/tqdb/parsers/boss.py
+++ b/tqdb/parsers/boss.py
@@ -100,7 +100,10 @@ class BossLootParser():
 
                     # Parse the table and multiply the values by the chance:
                     loot_ref = loot.get(f'loot{equipment}Item{i}')
-                    if not loot_ref:
+
+                    # There are some hero/boss files that have a '#' as
+                    # placeholder for a difficulty without loot, skip those:
+                    if not loot_ref or loot_ref == '#':
                         logging.warning(
                             f'Empty loot{equipment}Item{i} in {self.dbr}')
                         continue

--- a/tqdb/parsers/loot.py
+++ b/tqdb/parsers/loot.py
@@ -172,6 +172,10 @@ class LootFixedContainerParser:
         from tqdb.parsers.main import parser
 
         util = UtilityParser(self.dbr, self.props, self.strings)
+
+        if 'tables' not in self.props:
+            logging.warning(f'No table found in {self.dbr}')
+            return {}
         loot_dbr = util.get_reference_dbr(self.props['tables'])
         loot_props = parser.reader.read(loot_dbr)
 

--- a/tqdb/parsers/util.py
+++ b/tqdb/parsers/util.py
@@ -335,7 +335,12 @@ class UtilityParser:
         new_dbr = new_dbr.lower()
 
         # Create the reference
-        dbr_ref = self.dbr[:self.dbr.index(new_dbr.split('\\')[0])] + (new_dbr)
+        try:
+            dbr_ref = (self.dbr[:self.dbr.index(new_dbr.split('\\')[0])] +
+                       new_dbr)
+        except ValueError:
+            logging.warning(f'Value error parsing {new_dbr} in {self.dbr}')
+            return None
 
         # Quick check to avoid infinite recursion (new reference = self)
         return dbr_ref if self.dbr != dbr_ref else None

--- a/tqdb/utils/images.py
+++ b/tqdb/utils/images.py
@@ -1,4 +1,5 @@
 import glob
+import logging
 import os
 import subprocess
 
@@ -158,6 +159,7 @@ class SpriteCreator:
 ###############################################################################
 def save_bitmap(item, item_type, graphics, textures):
     if 'bitmap' not in item:
+        logging.warning(f'Missing bitmap for {item["tag"]}')
         return
 
     bitmap = item['bitmap']
@@ -185,3 +187,5 @@ def save_bitmap(item, item_type, graphics, textures):
                    f'{textures}{bitmap}',
                    f'{graphics}{tag}.png']
         subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    else:
+        logging.warning(f'Missing tag or bitmap for {item["tag"]}: {bitmap}')

--- a/tqdb/utils/images.py
+++ b/tqdb/utils/images.py
@@ -72,7 +72,9 @@ class SpriteCreator:
                         (f'{0 - sprite_height}px'
                          if 0 - sprite_height != 0
                          else 0 - sprite_height),
-                        f'{image_width}px' if image_width != 0 else image_width,
+                        (f'{image_width}px'
+                         if image_width != 0
+                         else image_width),
                         (f'{image_height}px'
                          if image_height != 0
                          else image_height)))
@@ -86,7 +88,9 @@ class SpriteCreator:
                         (f'{0 - sprite_height}px'
                          if 0 - sprite_height != 0
                          else 0 - sprite_height),
-                        f'{image_width}px' if image_width != 0 else image_width,
+                        (f'{image_width}px'
+                            if image_width != 0
+                            else image_width),
                         (f'{image_height}px'
                          if image_height != 0
                          else image_height)))
@@ -113,7 +117,9 @@ class SpriteCreator:
                         (f'{0 - sprite_height}px'
                          if 0 - sprite_height != 0
                          else 0 - sprite_height),
-                        f'{image_width}px' if image_width != 0 else image_width,
+                        (f'{image_width}px'
+                         if image_width != 0
+                         else image_width),
                         (f'{image_height}px'
                          if image_height != 0
                          else image_height)))


### PR DESCRIPTION
The loot tables are expanded to add Hero classed creatures and their loot to the tables. The data set needs to be inspected on the website to see if everything checks out (I'll add a ticket for some automated tests so there is some safe-guarding there).

Reference for #14