### PR TITLE
refactor: sort images to keep diffs consistent

### DIFF
--- a/tqdb/utils/images.py
+++ b/tqdb/utils/images.py
@@ -26,6 +26,9 @@ class SpriteCreator:
             image.filename = os.path.basename(file).split('.')[0]
             images.append(image)
 
+        # Sort images so output is consistent (useful for diffs)
+        images.sort()
+
         # Iterate through all the image objects and organize them by size
         for image in images:
             width, height = image.size


### PR DESCRIPTION
The stylesheet that's generated (and therefore the positioning of
the images in that stylesheet) is easier to diff if the images are
sorted before the converting occurs.