### PR TITLE
fix: use first occurence of tags for naming

### DIFF
--- a/tqdb/parsers/main.py
+++ b/tqdb/parsers/main.py
@@ -168,7 +168,8 @@ def parse_text_resource(text_file):
     # Parse line into a dictionary of key, value properties:
     return dict(
         properties.split('=', 1)
-        for properties in lines
+        # Reverse the list to make sure duplicate keys are corrected for
+        for properties in list(reversed(lines))
         if '=' in properties and not properties.startswith('//'))
 
 


### PR DESCRIPTION
Some of the tags seem to have duplicates with completely different
names. The game chooses to use the first tag it encounters. The
parser loads all tags sequentially without checking for duplicates
so to fix this bug, simply reverse the list so the "real" first
occurence of a tag is the one we end up with.

Fixes #20