### PR TITLE
Fix 64 bit registry read, various updates/improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ indent_size = 4
 end_of_line = lf
 charset = utf-8
 insert_final_nweline = true
-max_line_length = 80
+max_line_length = 120
 trim_trailing_whitespace = true
 
 [*.md]

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ indent_size = 4
 end_of_line = lf
 charset = utf-8
 insert_final_nweline = true
-max_line_length = 120
+max_line_length = 80
 trim_trailing_whitespace = true
 
 [*.md]

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 .pytest_cache
 data
 output
+.idea

--- a/README.md
+++ b/README.md
@@ -11,42 +11,57 @@ The result is two files containing all in-game information:
   - A single sprite image along with a CSS sprite sheet containing all the graphics for the equipment available in the JSON file.
 
 ## Automated Setup
+
 The `prepare.py` module automates most of the setup required, with the exception of the ARZ Database.
 
-This automated setup assumes that you have Titan Quest Anniversary Edition installed through Steam on your system. It will (currently) not work for other installation setups. Please report and issue describing your setup if it doesn't work for you.
+Automated setup assumes that you have Titan Quest Anniversary Edition installed through Steam. It will (currently) not work for other installation setups. Please report an issue describing your setup if it doesn't work for you.
 
-To run the automated setup, run `python prepare.py` in a terminal and then follow the ARZ Database instructions (chapter 1 of the Manual Setup) down below. No further setup will be required after.
+To run the automated setup:
+
+1. Run:
+
+    ```
+    python prepare.py
+    ```
+2. Next, set up the ARZ Database by following only item 1 of the Manual Setup instructions below.
 
 ## Manual Setup
-During the setup we're going to assume the following paths:
-- Repository: `c:/tqdb`
+
+During the setup we're going to use the following example paths:
+
+- Location of your clone of this git repository: `c:/tqdb`
 - TQ Install: `c:/Steam/SteamApps/Common/Titan Quest - Anniversary Edition/`
 
-The `data` directory needs to be created in your repository, so for this setup that would be `c:/tqdb/data`. Every time a directory needs to be created in the `data` directory, and is listed as `data/database` in the instructions, that means the full path would be: `c:/tqdb/data/database.`
+The `data` directory needs to be created in the same directory as your git clone, so for this example that would be `c:/tqdb/data`. Directories such as `data/database` are assumed to be relative to your cloned repo.
 
 ### Python
-Python 3.6 or higher and Pipenv are required to run this project. To get started with a clean setup, open up a shell, navigate to your local repository, and run:
+
+Python 3.6 or higher and Pipenv are required to run this project. To get started with a clean setup, open up a shell, navigate to this project, then run:
+
 - `pipenv clean`
 - `pipenv install`
 
 ### 1. ARZ Database
 
-1. Make sure the `data/database` directory exists in your local repository.
-2. Using the `ARZExtractor.exe` provided in the utils folder, extract the `database.arz` found in the `Database` folder in your Titan Quest install directory.
+1. Make sure the `data/database` directory exists. You will need about 2GB of free space.
+2. Run `utils/arzextractor/ARZExtractor.exe`
+3. Select the `Database/database.arz` file from your Titan Quest installation directory, choose `data/database` as the
+destination folder, and click Extract.
 
- **Source**: database.arz
- **Target**: data/database
+   **ARZ file**: database.arz
+ 
+   **Destination folder**: data/database
 
 ### 2. Templates
 
-1. Make sure the `data/database` directory exists in your local repository.
+1. Make sure the `data/database` directory exists.
 2. Open up a prompt, change directory to your TQ install.
 3. Run the following command:
 `ArchiveTool.exe Toolset/Templates.arc -extract C:/tqdb/data/database`
 
 ### 3. Text Resources
 
-1. Make sure the `data/resources` directory exists in your local repository.
+1. Make sure the `data/resources` directory exists.
 2. Choose a language you want to extract, and create the folder for it in the `resources` directory.
 For example, english would be: `data/resources/en`.
 The available locales are:
@@ -69,7 +84,7 @@ Replace the locale in both the arc file name and the directory to that of your c
 
 ### 4. Textures
 
-1. Make sure the following folders exist in your local repository:
+1. Make sure the following folders exist:
   - `data/textures/Items`
   - `data/textures/XPack/Items`
   - `data/textures/XPack2/Items`
@@ -81,7 +96,7 @@ Replace the locale in both the arc file name and the directory to that of your c
 
 ### 5. Quests
 
-1. Make sure the `data/quests` folder exists in your local repository.
+1. Make sure the `data/quests` folder exists.
 2. Open up a prompt, change directory to your TQ install.
 3. Run the following command:
     - `ArchiveTool.exe Resources/Quests.arc -extract C:/tqdb/data/quests`
@@ -89,6 +104,7 @@ Replace the locale in both the arc file name and the directory to that of your c
     - `ArchiveTool.exe Resources/XPack2/Quests.arc -extract C:/tqdb/data/quests`
 
 ## Running the parser
+
 `pipenv run python ./run.py` - Runs the parser with the default english locale
 `pipenv run python ./run.py --locale fr` - Runs the parser with the french locale
 

--- a/prepare.py
+++ b/prepare.py
@@ -2,6 +2,7 @@
 Utility module to prepare the data for the parser.
 
 """
+import logging
 import subprocess
 import winreg
 
@@ -73,21 +74,24 @@ def tqdb_prepare():
         elif bitness == '64bit':
             other_view_flag = winreg.KEY_WOW64_32KEY
         else:
-            raise RuntimeError("Platform architecture not recognized: " + bitness)
+            raise RuntimeError("Platform architecture not recognized: " +
+                               bitness)
 
         try:
             tqae_key = winreg.OpenKey(
-                winreg.HKEY_LOCAL_MACHINE, LOOKUP_KEY, access = winreg.KEY_READ | other_view_flag)
+                winreg.HKEY_LOCAL_MACHINE, LOOKUP_KEY,
+                access = winreg.KEY_READ | other_view_flag)
         except WindowsError as err:
-            raise RuntimeError('Could not find installation directory for Titan Quest.') from err
+            raise RuntimeError('Could not find installation directory for '
+                               'Titan Quest.') from err
 
     try:
         install = winreg.QueryValueEx(tqae_key, 'InstallLocation')[0]
     except WindowsError as err:
-        print('Could not find installation directory for Titan Quest.', err)
-        return
+        raise RuntimeError('Could not find installation directory for Titan '
+                           'Quest.') from err
 
-    print("Found TQ installation directory: " + install)
+    logging.info("Found TQ installation directory: " + install)
 
     # Create the required directories if necessary
     for d in DIRECTORIES:

--- a/run.py
+++ b/run.py
@@ -2,6 +2,8 @@ import argparse
 import json
 import logging
 
+import time
+
 from tqdb import __version__ as tqdb_version
 from tqdb import main
 from tqdb import storage
@@ -12,8 +14,8 @@ from tqdb.utils.text import texts
 logging.getLogger('PIL').setLevel(logging.WARNING)
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s %(message)s',
-    datefmt='%H:%M')
+    format='%(asctime)s %(levelname)s %(message)s',
+    datefmt='%H:%M:%S')
 
 # Supported languages
 LANGUAGES = [
@@ -87,12 +89,17 @@ def tqdb():
     # Grab the arguments:
     args = argparser.parse_args()
 
+    def create_sprite_sheet():
+        start_time = time.time()
+        images.SpriteCreator('output/graphics/', 'output')
+        logging.info(f"Sprite sheet took {time.time() - start_time:.2f}s")
+
     if not args.all_languages:
         # Parse the specified language:
         tqdb_language(args.locale)
 
-        # Create the sprite for a single language
-        images.SpriteCreator('output/graphics/', 'output')
+        # Create the sprite sheet for a single language
+        create_sprite_sheet()
 
         # Stop here
         return
@@ -102,8 +109,8 @@ def tqdb():
         tqdb_language(language)
         storage.reset()
 
-    # Create the sprite after all languages have been parsed:
-    images.SpriteCreator('output/graphics/', 'output')
+    # Create the sprite sheet after all languages have been parsed:
+    create_sprite_sheet()
 
 if __name__ == '__main__':
     tqdb()

--- a/tqdb/dbr.py
+++ b/tqdb/dbr.py
@@ -11,7 +11,7 @@ the DBR and then parse it according to all properties in that template.
 import logging
 
 from tqdb import storage
-from tqdb.parsers.main import load_parsers
+from tqdb.parsers.main import load_parsers, InvalidItemError
 from tqdb.templates import templates, templates_by_path
 
 
@@ -22,6 +22,10 @@ def get_template(dbr, dbr_file):
     """
     Attempts to retrieve a template for a DBR.
 
+    :param dbr: a dict with key 'templateName' referring to a template file,
+        or with key 'Class' referring to a template with a "Class" variable with
+        that "defaultValue"
+    :param dbr_file: the file the dbr came from, for logging purposes
     """
     if 'templateName' in dbr:
         # The template path is set, retrieve it from the collection:
@@ -40,7 +44,35 @@ def read(dbr):
 
     """
     try:
-        dbr_file = open(dbr)
+        with open(dbr) as dbr_file:
+            result = {}
+
+            # DBR lines always end with ',\n' which we remove
+            lines = (line.rstrip(',\n') for line in dbr_file)
+
+            # Only add properties that have the correct format per line of: key,value
+            properties = dict(tuple(line.split(',', 1)) for line in lines if ',' in line)
+
+            # The 'templateName' property isn't in any Template, so add manually:
+            if 'templateName' in properties:
+                result['templateName'] = properties['templateName']
+
+            # Get the template for this DBR
+            template = get_template(properties, dbr)
+
+            def parse_vars_to_tuples(variables_dict):
+                for name, variable in variables_dict.items():
+                    if name in properties:
+                        parsed_value = variable.parse_value(properties[name])
+                        # Omit None, False, zero, and empty collections
+                        if parsed_value:
+                            yield (name, parsed_value)
+
+            # Now parse all properties using the Template:
+            result.update(dict(parse_vars_to_tuples(template.variables)))
+
+            return result
+
     except FileNotFoundError:
         logging.debug(f'No file found for {dbr}')
         return {}
@@ -48,36 +80,14 @@ def read(dbr):
         logging.debug(f'Tried opening a directory {dbr}')
         return {}
 
-    result = {}
 
-    # Put all the DBR lines (that always end with ,\n) in a list
-    lines = [line.rstrip(',\n') for line in dbr_file]
-
-    # Only add properties that have the correct format per line of: key,value
-    properties = dict(line.split(',') for line in lines if ',' in line)
-
-    # The 'templateName' property isn't in any Template, so add manually:
-    if 'templateName' in properties:
-        result['templateName'] = properties['templateName']
-
-    # Get the template for this DBR
-    template = get_template(properties, dbr)
-
-    # Now parse all properties using the Template:
-    result.update(dict(
-        (name, variable.parse_value(properties[name])) for
-        name, variable in template.variables.items()
-        if name in properties and
-        variable.parse_value(properties[name])))
-
-    return result
-
-
-def parse(dbr_file, references={}):
+def parse(dbr_file, references=None):
     """
     Parse a DBR file according to its template.
 
     """
+    if references is None:
+        references = {}
     # Initialize the parsers map if necessary:
     global parsers
     if not parsers:
@@ -124,14 +134,16 @@ def parse(dbr_file, references={}):
     for prioritized_parser in prioritized:
         try:
             prioritized_parser.parse(dbr, dbr_file, result)
-        except StopIteration:
+        except InvalidItemError as e:
             # One of the parsers has determined this file shouldn't be parsed:
-            return {}
+            raise InvalidItemError(f"Parser {prioritized_parser} for template key "
+                                   f"{prioritized_parser.template.key} tells us this item "
+                                   f"is invalid and should be ignored.") from e
 
     # Pop the helper data references again:
     result.pop('references')
 
-    # Set the parsed result in the storage db:
+    # Retain the parsed result in memory, for reuse:
     storage.db[dbr_file] = result
 
     return result

--- a/tqdb/parsers/base.py
+++ b/tqdb/parsers/base.py
@@ -2,9 +2,11 @@
 Base templates that are often included by other templates.
 
 """
+import logging
+
 from tqdb import dbr as DBRParser
 from tqdb import storage
-from tqdb.parsers.main import TQDBParser
+from tqdb.parsers.main import TQDBParser, InvalidItemError
 from tqdb.utils.text import texts
 
 # Some shared core constants:
@@ -359,12 +361,16 @@ class ItemSkillAugmentParser(TQDBParser):
         Parse a granted skill.
 
         """
-        # Skip files without both granted skill name and level:
+        # If it doesn't have a granted skill name and level, it grants no skills:
         if self.SKILL_NAME not in dbr or self.SKILL_LEVEL not in dbr:
             return
 
         level = dbr[self.SKILL_LEVEL]
-        skill = DBRParser.parse(dbr[self.SKILL_NAME])
+        try:
+            skill = DBRParser.parse(dbr[self.SKILL_NAME])
+        except InvalidItemError as e:
+            logging.debug(f"Skipping granted skill record in {dbr[self.SKILL_NAME]}. {e}")
+            return
 
         if 'name' not in skill:
             return

--- a/tqdb/parsers/creatures.py
+++ b/tqdb/parsers/creatures.py
@@ -8,7 +8,7 @@ from tqdb import dbr as DBRParser
 from tqdb import storage
 from tqdb.constants.resources import DB, CHESTS
 from tqdb.parsers import base as parsers
-from tqdb.parsers.main import TQDBParser
+from tqdb.parsers.main import TQDBParser, InvalidItemError
 from tqdb.utils.text import texts
 
 
@@ -254,7 +254,12 @@ class MonsterParser(TQDBParser):
                     logging.debug(f'No {loot_key} in {dbr_file}')
                     continue
 
-                loot = DBRParser.parse(loot_file, {'level': dbr['charLevel']})
+                try:
+                    loot = DBRParser.parse(loot_file, {'level': dbr['charLevel']})
+                except InvalidItemError as e:
+                    logging.debug(f"Skipping loot item in {loot_file} because it's invalid. {e}")
+                    continue
+
                 if 'tag' in loot:
                     # Add a single item that was found:
                     self.add_items(
@@ -342,7 +347,11 @@ class MonsterSkillManager(TQDBParser):
                     str(dbr[nameTag]).lower() in self.IGNORE_SKILLS):
                 continue
 
-            skill = DBRParser.parse(dbr[nameTag])
+            try:
+                skill = DBRParser.parse(dbr[nameTag])
+            except InvalidItemError as e:
+                logging.debug(f"Skipping creature skill {nameTag} in {dbr_file} because it's invalid. {e}")
+                continue
             if not skill['properties']:
                 continue
 

--- a/tqdb/parsers/equipment.py
+++ b/tqdb/parsers/equipment.py
@@ -110,7 +110,9 @@ class ItemArtifactFormulaParser(TQDBParser):
         try:
             bonuses = DBRParser.parse(dbr['artifactBonusTableName'])
         except InvalidItemError as e:
-            logging.debug(f"Could not parse artifact completion bonus information for {result['name']} in {dbr_file}. {e}")
+            logging.debug("Could not parse artifact completion bonus "
+                          f"information for {result['name']} in {dbr_file}. "
+                          f"{e}")
 
         result['bonus'] = bonuses.get('table', [])
 
@@ -176,7 +178,9 @@ class ItemBaseParser(TQDBParser):
 
         if (itemClass not in self.ALLOWED and
                 classification not in self.CLASSIFICATIONS.keys()):
-            raise InvalidItemError(f"Item {dbr_file} is excluded due to Class {itemClass} with itemClassification {classification}.")
+            raise InvalidItemError(f"Item {dbr_file} is excluded due to Class "
+                                   f"{itemClass} with itemClassification "
+                                   f"{classification}.")
         elif (classification in self.CLASSIFICATIONS.keys() and
                 'classification' not in result):
             # Only add the classification if it doesn't exist yet:
@@ -188,8 +192,8 @@ class ItemBaseParser(TQDBParser):
                 file_name = os.path.basename(dbr_file).split('_')
                 if len(file_name) < 2 or file_name[1] not in DIFFICULTIES:
                     raise InvalidItemError(f"File name {file_name} does not "
-                                        f"specify difficulty, or difficulty "
-                                        f"not recognized.")
+                                           "specify difficulty, or difficulty "
+                                           "not recognized.")
 
                 # Set the difficulty for which this MI drops:
                 result['dropsIn'] = texts.get(
@@ -338,7 +342,8 @@ class ItemRelicParser(TQDBParser):
         try:
             bonuses = DBRParser.parse(dbr['bonusTableName'])
         except InvalidItemError as e:
-            logging.debug(f"Could not parse relic completion bonus information for {result['name']} in {dbr_file}. {e}")
+            logging.debug("Could not parse relic completion bonus information "
+                          f"for {result['name']} in {dbr_file}. {e}")
 
         result['bonus'] = bonuses.get('table', [])
 
@@ -404,7 +409,8 @@ class ItemSetParser(TQDBParser):
             try:
                 set_member = DBRParser.parse(set_member_path)
             except InvalidItemError as e:
-                logging.debug(f"Could not parse set member {set_member_path} in {result['name']}. {e}")
+                logging.debug(f"Could not parse set member {set_member_path} "
+                              f"in {result['name']}. {e}")
                 continue
 
             # Some sets are templates that don't have actual members
@@ -504,7 +510,8 @@ class OneShotScrollParser(TQDBParser):
         try:
             skill = DBRParser.parse(dbr['skillName'])
         except InvalidItemError as e:
-            logging.debug(f"Could not parse skill {dbr['skillName']} from scroll {result['name']}. {e}")
+            logging.debug(f"Could not parse skill {dbr['skillName']} from "
+                          f"scroll {result['name']}. {e}")
 
         # Add the first tier of properties if there are any:
         if 'properties' in skill and skill['properties']:
@@ -556,7 +563,7 @@ class WeaponParser(TQDBParser):
         dbr_class = dbr['Class']
 
         # Skip shields:
-        if (dbr_class.startswith('Weapon') and 'Shield' in dbr_class):
+        if dbr_class.startswith('Weapon') and 'Shield' in dbr_class:
             return
 
         # Set the attack speed

--- a/tqdb/parsers/main.py
+++ b/tqdb/parsers/main.py
@@ -11,6 +11,14 @@ from pathlib import Path
 
 from tqdb.templates import templates_by_path
 
+class InvalidItemError(Exception):
+    """
+    Raised by parser when it identifies that the item being parsed is invalid
+    and should be ignored. This may be because it is missing crucial information,
+    or because it's filtered out because it's uninteresting, for example if it
+    is a common item.
+    """
+    pass
 
 class TQDBParser(metaclass=abc.ABCMeta):
     """

--- a/tqdb/utils/images.py
+++ b/tqdb/utils/images.py
@@ -24,118 +24,128 @@ class SpriteCreator:
         images_map = {}
         images = []
 
-        # Iterate through all the files and make a list of the image objects
-        for file in glob.glob(f'{sprite_dir}\\*.png'):
-            image = Image.open(file)
-            image.filename = os.path.basename(file).split('.')[0]
-            images.append(image)
+        try:
+            # Iterate through all the files and make a list of the image objects
+            for file in glob.glob(f'{sprite_dir}\\*.png'):
+                image = Image.open(file)
+                image.filename = os.path.basename(file).split('.')[0]
+                images.append(image)
 
-        # Sort images so output is consistent (useful for diffs)
-        images.sort(key=lambda x: x.filename)
+            if len(images) <= 0:
+                logging.warning(f"No images found in {sprite_dir}. Skipping creation of sprite sheet.")
+                return
 
-        # Iterate through all the image objects and organize them by size
-        for image in images:
-            width, height = image.size
+            logging.info(f"Combining {len(images)} images into a sprite sheet.")
 
-            # Append this image to its size list, or create a new size list
-            key = f'{width}x{height}'
-            if key in images_map:
-                images_map[key].append(image)
-            else:
-                images_map[key] = [image]
+            # Sort images so output is consistent (useful for diffs)
+            images.sort(key=lambda x: x.filename)
 
-        # Keep a sorted list of the keys (descending by height):
-        sorted_keys = list(images_map.keys())
-        sorted_keys.sort(key=lambda x: int(x.split('x')[1]))
+            # Iterate through all the image objects and organize them by size
+            for image in images:
+                width, height = image.size
 
-        # Maximum width of the sprite is 768px
-        sprite_width = 768
-        sprite_height = 0
-        sprite_css = ('.{0} {{\n'
-                      '  background-position: {1} {2};\n'
-                      '  width: {3};\n'
-                      '  height: {4};\n}}\n')
-
-        # Keep track of the canvases (per size) and css (per image)
-        css = []
-        canvases = []
-
-        # Run through the keys (sorted by descending height)
-        for key in sorted_keys:
-            canvas_width, canvas_height = tuple(map(int, key.split('x')))
-
-            canvas = Image.new(mode='RGBA',
-                               size=(sprite_width, canvas_height),
-                               color=(0, 0, 0, 0))
-            x = 0
-
-            # Iterate over all the images in this size:
-            for index, image in enumerate(images_map[key]):
-                image_width, image_height = image.size
-                if x + image_width < sprite_width:
-                    canvas.paste(image, (x, 0))
-                    css.append(sprite_css.format(
-                        image.filename,
-                        f'{0 - x}px' if 0 - x != 0 else 0 - x,
-                        (f'{0 - sprite_height}px'
-                         if 0 - sprite_height != 0
-                         else 0 - sprite_height),
-                        (f'{image_width}px'
-                         if image_width != 0
-                         else image_width),
-                        (f'{image_height}px'
-                         if image_height != 0
-                         else image_height)))
-                    x += image_width
-
-                elif x + image_width == sprite_width:
-                    canvas.paste(image, (x, 0))
-                    css.append(sprite_css.format(
-                        image.filename,
-                        f'{0 - x}px' if 0 - x != 0 else 0 - x,
-                        (f'{0 - sprite_height}px'
-                         if 0 - sprite_height != 0
-                         else 0 - sprite_height),
-                        (f'{image_width}px'
-                            if image_width != 0
-                            else image_width),
-                        (f'{image_height}px'
-                         if image_height != 0
-                         else image_height)))
-
-                    if index == len(images_map[key]) - 1:
-                        # Last image, append canvas:
-                        canvases.append(canvas)
-                        sprite_height += canvas_height
-                    else:
-                        # More images to come, reset row:
-                        x += image_width
+                # Append this image to its size list, or create a new size list
+                key = f'{width}x{height}'
+                if key in images_map:
+                    images_map[key].append(image)
                 else:
+                    images_map[key] = [image]
+
+            # Keep a sorted list of the keys (descending by height):
+            sorted_keys = list(images_map.keys())
+            sorted_keys.sort(key=lambda x: int(x.split('x')[1]))
+
+            # Maximum width of the sprite is 768px
+            sprite_width = 768
+            sprite_height = 0
+            sprite_css = ('.{0} {{\n'
+                          '  background-position: {1} {2};\n'
+                          '  width: {3};\n'
+                          '  height: {4};\n}}\n')
+
+            # Keep track of the canvases (per size) and css (per image)
+            css = []
+            canvases = []
+
+            # Run through the keys (sorted by descending height)
+            for key in sorted_keys:
+                canvas_width, canvas_height = tuple(map(int, key.split('x')))
+
+                canvas = Image.new(mode='RGBA',
+                                   size=(sprite_width, canvas_height),
+                                   color=(0, 0, 0, 0))
+                x = 0
+
+                # Iterate over all the images in this size:
+                for index, image in enumerate(images_map[key]):
+                    image_width, image_height = image.size
+                    if x + image_width < sprite_width:
+                        canvas.paste(image, (x, 0))
+                        css.append(sprite_css.format(
+                            image.filename,
+                            f'{0 - x}px' if 0 - x != 0 else 0 - x,
+                            (f'{0 - sprite_height}px'
+                             if 0 - sprite_height != 0
+                             else 0 - sprite_height),
+                            (f'{image_width}px'
+                             if image_width != 0
+                             else image_width),
+                            (f'{image_height}px'
+                             if image_height != 0
+                             else image_height)))
+                        x += image_width
+
+                    elif x + image_width == sprite_width:
+                        canvas.paste(image, (x, 0))
+                        css.append(sprite_css.format(
+                            image.filename,
+                            f'{0 - x}px' if 0 - x != 0 else 0 - x,
+                            (f'{0 - sprite_height}px'
+                             if 0 - sprite_height != 0
+                             else 0 - sprite_height),
+                            (f'{image_width}px'
+                                if image_width != 0
+                                else image_width),
+                            (f'{image_height}px'
+                             if image_height != 0
+                             else image_height)))
+
+                        if index == len(images_map[key]) - 1:
+                            # Last image, append canvas:
+                            canvases.append(canvas)
+                            sprite_height += canvas_height
+                        else:
+                            # More images to come, reset row:
+                            x += image_width
+                    else:
+                        canvases.append(canvas)
+                        canvas = Image.new(mode='RGBA',
+                                           size=(sprite_width, canvas_height),
+                                           color=(0, 0, 0, 0))
+                        canvas.paste(image, (0, 0))
+                        x = image_width
+                        sprite_height += canvas_height
+
+                        css.append(sprite_css.format(
+                            image.filename,
+                            0,
+                            (f'{0 - sprite_height}px'
+                             if 0 - sprite_height != 0
+                             else 0 - sprite_height),
+                            (f'{image_width}px'
+                             if image_width != 0
+                             else image_width),
+                            (f'{image_height}px'
+                             if image_height != 0
+                             else image_height)))
+
+                # Append last row
+                if x < sprite_width:
                     canvases.append(canvas)
-                    canvas = Image.new(mode='RGBA',
-                                       size=(sprite_width, canvas_height),
-                                       color=(0, 0, 0, 0))
-                    canvas.paste(image, (0, 0))
-                    x = image_width
                     sprite_height += canvas_height
-
-                    css.append(sprite_css.format(
-                        image.filename,
-                        0,
-                        (f'{0 - sprite_height}px'
-                         if 0 - sprite_height != 0
-                         else 0 - sprite_height),
-                        (f'{image_width}px'
-                         if image_width != 0
-                         else image_width),
-                        (f'{image_height}px'
-                         if image_height != 0
-                         else image_height)))
-
-            # Append last row
-            if x < sprite_width:
-                canvases.append(canvas)
-                sprite_height += canvas_height
+        finally:
+            for image in images:
+                image.close()
 
         # Create the new sprite image
         sprite_image = Image.new(mode='RGBA',


### PR DESCRIPTION
- Updated to Python 3.8. Updated libraries.
- Fixed issue loading 64 bit Windows registry values.
- When one of the parsers decides the DBR should be ignored because it
is invalid, rather than returning a somewhat mysterious empty dict,
it now throws an InvalidItemError with relevant information in it.
This helps prevent those empty dicts from accidentally being added to
inappropriate places, because the exception must be handled in order for
the code to continue running. Checks have been added around calls to
parse() which should maintain equivalent behavior to the preexisting
code. However, informative debug log messages have been added where
appropriate.
- Parsers now use InvalidItemError rather than StopIteration because
the parser function is just a regular function call, it's not an
iterator next() call.
- If no images are available for creating a sprite sheet, we log a
useful warning message rather than allowing PIL function calls to raise
a somewhat confusing error. Also, we now explicitly close all image
objects once we no longer need them.
- DBR read now uses "with" to automatically close the file.
- DBR read using generator comprehension rather than list comprehension
when we don't actually need to create a list and can instead process
items one at a time.
- DBR read no longer calls variable.parse_value() twice for each
variable.
- Fixed IDE warning about using mutable default value in arg to parse()
- Simplified equipment file iteration, and made the filtering of
particular folders platform-agnostic which were previously Windows
specific.
- In regex: pipe character twice in character class is redundant.
Escaping forward slash is unnecessary.
- In the README, clarify that the "C:/tqdb" path is not actually
required, it is just an example. Also, now referring to the project
directory more as the "git clone" rather than as the "repository" which
is a little confusing.